### PR TITLE
fix: download buttons now resolve to direct binary URLs

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -391,9 +391,9 @@
 
     (function() {
       var repo = 'rohitg00/openclawd';
-      var releasesUrl = 'https://github.com/' + repo + '/releases/latest';
-      var apiUrl = 'https://api.github.com/repos/' + repo + '/releases/latest';
-      var cacheKey = 'openclawd_release_cache';
+      var releasesUrl = 'https://github.com/' + repo + '/releases';
+      var apiUrl = 'https://api.github.com/repos/' + repo + '/releases?per_page=5';
+      var cacheKey = 'openclawd_release_cache_v2';
       var cacheTTL = 10 * 60 * 1000;
       var buttons = document.querySelectorAll('.download-btn[data-pattern]');
 
@@ -412,6 +412,14 @@
         }
       });
 
+      function findReleaseWithAssets(releases) {
+        if (!Array.isArray(releases)) return null;
+        for (var i = 0; i < releases.length; i++) {
+          if (releases[i].assets && releases[i].assets.length > 0) return releases[i];
+        }
+        return null;
+      }
+
       function resolveAssets(release) {
         if (!release || !release.assets) return;
         buttons.forEach(function(btn) {
@@ -419,8 +427,6 @@
           var asset = release.assets.find(function(a) { return a.name.indexOf(pattern) !== -1; });
           if (asset) {
             btn.href = asset.browser_download_url;
-          } else {
-            btn.href = releasesUrl;
           }
         });
       }
@@ -436,7 +442,8 @@
       fetch(apiUrl).then(function(r) {
         if (!r.ok) return null;
         return r.json();
-      }).then(function(release) {
+      }).then(function(releases) {
+        var release = findReleaseWithAssets(releases);
         if (!release) return;
         try { sessionStorage.setItem(cacheKey, JSON.stringify({ ts: Date.now(), data: release })); } catch(e) {}
         resolveAssets(release);


### PR DESCRIPTION
## Summary
Download buttons were not auto-downloading binaries because:
1. `/releases/latest` API returned v0.2.0 which initially had 0 assets (CI hadn't uploaded yet)
2. The script only checked the latest release, not any release with assets

## Fix
- Fetch `?per_page=5` releases and pick the **first release with assets**
- Handles the race condition where CI is still uploading to the latest release
- Invalidated stale cache (new key `_v2`)

## Verified
All 5 patterns resolve correctly:
- `mac-arm64.dmg` -> `OpenClawd-0.2.0-mac-arm64.dmg`
- `mac-x64.dmg` -> `OpenClawd-0.2.0-mac-x64.dmg`
- `win-x64.exe` -> `OpenClawd-0.2.0-win-x64.exe`
- `.AppImage` -> `OpenClawd-0.2.0.AppImage`
- `amd64.deb` -> `openclawd-cli_0.2.0_amd64.deb`